### PR TITLE
JAX-RS Resource method support improvements

### DIFF
--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpMethodInfo.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpMethodInfo.java
@@ -67,10 +67,7 @@ class HttpMethodInfo {
         this.exceptionHandler = exceptionHandler;
 
         // The actual arguments list to invoke handler method
-        this.args = new Object[args.length + 2];
-        this.args[0] = request;
-        this.args[1] = responder;
-        System.arraycopy(args, 0, this.args, 2, args.length);
+        this.args = args;
     }
 
     /**

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpMethodInfo.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpMethodInfo.java
@@ -89,7 +89,9 @@ class HttpMethodInfo {
             // Actually <T> would be void
             bodyConsumer = null;
             try {
-                method.invoke(handler, args);
+                Object returnVal = method.invoke(handler, args);
+                //sending return value as output
+                new HttpMethodResponseHandler().setResponder(responder).setEntity(returnVal).send();
             } catch (InvocationTargetException e) {
                 exceptionHandler.handle(e.getTargetException(), request, responder);
             }

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpMethodResponseHandler.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpMethodResponseHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.mss.internal.router;
+
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.gson.JsonObject;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.wso2.carbon.mss.HttpResponder;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+/**
+ * Handles the return values of the resource methods
+ * of JAX-RS resource classes
+ */
+public class HttpMethodResponseHandler {
+
+    private HttpResponder responder;
+    private HttpResponseStatus status = HttpResponseStatus.OK;
+    private Object entity;
+
+    /**
+     * Set netty-http responder object
+     *
+     * @param responder
+     */
+    public HttpMethodResponseHandler setResponder(HttpResponder responder) {
+        this.responder = responder;
+        return this;
+    }
+
+    /**
+     * Set response http status code
+     *
+     * @param status http status code
+     */
+    public HttpMethodResponseHandler setStatus(int status) {
+        this.status = HttpResponseStatus.valueOf(status);
+        return this;
+    }
+
+    /**
+     * Set entity body for the response.
+     *
+     * @param entity
+     */
+    public HttpMethodResponseHandler setEntity(Object entity) {
+        this.entity = entity;
+        return this;
+    }
+
+    /**
+     * send response using netty-http provided responder
+     */
+    public void send() {
+        if (entity == null) {
+            responder.sendStatus(HttpResponseStatus.NO_CONTENT);
+        } else if (entity instanceof JsonObject) {
+            //TODO: check no header support
+            responder.sendJson(status, entity);
+        } else if (entity instanceof String) {
+            responder.sendString(status, (String) entity);
+        } else {
+            responder.sendString(status, String.valueOf(entity));
+        }
+    }
+}

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpMethodResponseHandler.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpMethodResponseHandler.java
@@ -32,7 +32,7 @@ import javax.ws.rs.core.Response;
 public class HttpMethodResponseHandler {
 
     private HttpResponder responder;
-    private HttpResponseStatus status = HttpResponseStatus.OK;
+    private HttpResponseStatus status = null;
     private Object entity;
     private Multimap<String, String> headers = null;
 
@@ -85,15 +85,25 @@ public class HttpMethodResponseHandler {
      * send response using netty-http provided responder
      */
     public void send() {
-        if (entity == null) {
-            responder.sendStatus(HttpResponseStatus.NO_CONTENT, headers);
-        } else if (entity instanceof JsonObject) {
-            //TODO: check no header support
-            responder.sendJson(status, entity);
-        } else if (entity instanceof String) {
-            responder.sendString(status, (String) entity, headers);
+        HttpResponseStatus status;
+        if (this.status != null) {
+            status = this.status;
+        } else if (entity != null) {
+            status = HttpResponseStatus.OK;
         } else {
-            responder.sendString(status, String.valueOf(entity), headers);
+            status = HttpResponseStatus.NO_CONTENT;
+        }
+        if (entity != null) {
+            if (entity instanceof JsonObject) {
+                //TODO: check no header support
+                responder.sendJson(status, entity);
+            } else if (entity instanceof String) {
+                responder.sendString(status, (String) entity, headers);
+            } else {
+                responder.sendString(status, String.valueOf(entity), headers);
+            }
+        } else {
+            responder.sendStatus(status, headers);
         }
     }
 }

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpResourceHandler.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpResourceHandler.java
@@ -19,7 +19,6 @@
 
 package org.wso2.carbon.mss.internal.router;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpResourceHandler.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpResourceHandler.java
@@ -82,19 +82,13 @@ public final class HttpResourceHandler implements HttpHandler {
             }
 
             for (Method method : handler.getClass().getDeclaredMethods()) {
-                if (method.getParameterTypes().length >= 2 &&
-                        method.getParameterTypes()[0].isAssignableFrom(HttpRequest.class) &&
-                        method.getParameterTypes()[1].isAssignableFrom(HttpResponder.class) &&
-                        Modifier.isPublic(method.getModifiers())) {
-
+                Set<HttpMethod> httpMethods = getHttpMethods(method);
+                if (Modifier.isPublic(method.getModifiers()) && !httpMethods.isEmpty()) {
                     String relativePath = "";
                     if (method.getAnnotation(Path.class) != null) {
                         relativePath = method.getAnnotation(Path.class).value();
                     }
                     String absolutePath = String.format("%s/%s", basePath, relativePath);
-                    Set<HttpMethod> httpMethods = getHttpMethods(method);
-                    Preconditions.checkArgument(httpMethods.size() >= 1,
-                            String.format("No HttpMethod found for method: %s", method.getName()));
                     patternRouter.add(absolutePath, new HttpResourceModel(httpMethods, absolutePath, method,
                             handler, exceptionHandler));
                 } else {
@@ -199,7 +193,7 @@ public final class HttpResourceHandler implements HttpHandler {
             } else {
                 responder.sendString(HttpResponseStatus.NOT_FOUND,
                         String.format("Problem accessing: %s. Reason: Not Found",
-                        request.getUri()));
+                                request.getUri()));
             }
         } catch (Throwable t) {
             responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpResourceModel.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/HttpResourceModel.java
@@ -213,22 +213,17 @@ public final class HttpResourceModel {
      * Gathers all parameters' annotations for the given method, starting from the third parameter.
      */
     private List<Map<Class<? extends Annotation>, ParameterInfo<?>>> createParametersInfos(Method method) {
-        if (method.getParameterTypes().length <= 2) {
-            return ImmutableList.of();
-        }
-
         ImmutableList.Builder<Map<Class<? extends Annotation>, ParameterInfo<?>>> result = ImmutableList.builder();
         Type[] parameterTypes = method.getGenericParameterTypes();
         Annotation[][] parameterAnnotations = method.getParameterAnnotations();
 
-        for (int i = 2; i < parameterAnnotations.length; i++) {
+        for (int i = 0; i < parameterAnnotations.length; i++) {
             Annotation[] annotations = parameterAnnotations[i];
             Map<Class<? extends Annotation>, ParameterInfo<?>> paramAnnotations = Maps.newIdentityHashMap();
 
             for (Annotation annotation : annotations) {
                 Class<? extends Annotation> annotationType = annotation.annotationType();
                 ParameterInfo<?> parameterInfo;
-
                 if (PathParam.class.isAssignableFrom(annotationType)) {
                     parameterInfo = ParameterInfo.create(annotation,
                             ParamConvertUtils.createPathParamConverter(parameterTypes[i]));
@@ -241,12 +236,11 @@ public final class HttpResourceModel {
                 } else {
                     parameterInfo = ParameterInfo.create(annotation, null);
                 }
-
                 paramAnnotations.put(annotationType, parameterInfo);
             }
 
-            // Must have either @PathParam, @QueryParam or @HeaderParam, but not two or more.
-            if (Sets.intersection(SUPPORTED_PARAM_ANNOTATIONS, paramAnnotations.keySet()).size() != 1) {
+            //Can have only one from @PathParam, @QueryParam or @HeaderParam.
+            if (Sets.intersection(SUPPORTED_PARAM_ANNOTATIONS, paramAnnotations.keySet()).size() > 1) {
                 throw new IllegalArgumentException(
                         String.format("Must have exactly one annotation from %s for parameter %d in method %s",
                                 SUPPORTED_PARAM_ANNOTATIONS, i, method));
@@ -254,7 +248,6 @@ public final class HttpResourceModel {
 
             result.add(Collections.unmodifiableMap(paramAnnotations));
         }
-
         return result.build();
     }
 

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/MSSResponse.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/MSSResponse.java
@@ -18,6 +18,13 @@
 
 package org.wso2.carbon.mss.internal.router;
 
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.GenericType;
@@ -28,13 +35,6 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Variant;
-import java.lang.annotation.Annotation;
-import java.net.URI;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Trimmed MSS implementation of javax.ws.rs.core.Response

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/MSSResponse.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/MSSResponse.java
@@ -1,0 +1,364 @@
+/*
+ *
+ *  * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.wso2.carbon.mss.internal.router;
+
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Variant;
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Trimmed MSS implementation of javax.ws.rs.core.Response
+ */
+public class MSSResponse extends Response {
+
+    private Object entity;
+    private int status;
+    private MultivaluedMap<String, String> headers;
+    private MediaType type;
+
+    public void setEntity(Object entity) {
+        this.entity = entity;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    public void setHeaders(MultivaluedMap<String, String> headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public StatusType getStatusInfo() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getEntity() {
+        return entity;
+    }
+
+    @Override
+    public <T> T readEntity(Class<T> entityType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T readEntity(GenericType<T> entityType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T readEntity(Class<T> entityType, Annotation[] annotations) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T readEntity(GenericType<T> entityType, Annotation[] annotations) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasEntity() {
+        return false;
+    }
+
+    @Override
+    public boolean bufferEntity() {
+        return false;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public MediaType getMediaType() {
+        return type;
+    }
+
+    @Override
+    public Locale getLanguage() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getLength() {
+        return 0;
+    }
+
+    @Override
+    public Set<String> getAllowedMethods() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, NewCookie> getCookies() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public EntityTag getEntityTag() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Date getDate() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Date getLastModified() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI getLocation() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<Link> getLinks() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasLink(String relation) {
+        return false;
+    }
+
+    @Override
+    public Link getLink(String relation) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Link.Builder getLinkBuilder(String relation) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MultivaluedMap<String, Object> getMetadata() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MultivaluedMap<String, String> getStringHeaders() {
+        return headers;
+    }
+
+    @Override
+    public String getHeaderString(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setType(MediaType type) {
+        this.type = type;
+    }
+
+    /**
+     * Trimmed Convenient builder for MSSResponse instances
+     */
+    public static class Builder extends ResponseBuilder {
+
+        private Object entity;
+        private int status;
+        private MultivaluedMap<String, String> headers;
+        private MediaType type;
+
+        @Override
+        public Response build() {
+            MSSResponse mssResponse = new MSSResponse();
+            mssResponse.setStatus(status);
+            mssResponse.setEntity(entity);
+            mssResponse.setHeaders(headers);
+            mssResponse.setType(type);
+            return mssResponse;
+        }
+
+        @Override
+        public ResponseBuilder clone() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder status(int status) {
+            this.status = status;
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder entity(Object entity) {
+            this.entity = entity;
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder entity(Object entity, Annotation[] annotations) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder allow(String... methods) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder allow(Set<String> methods) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder cacheControl(CacheControl cacheControl) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder encoding(String encoding) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder header(String name, Object value) {
+            if (headers == null) {
+                headers = new MultivaluedHashMap<>();
+            }
+            if (value instanceof List) {
+                List values = (List) value;
+                for (Object valueElement : values) {
+                    headers.add(name, valueElement.toString());
+                }
+            } else {
+                headers.add(name, value.toString());
+            }
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder replaceAll(MultivaluedMap<String, Object> headers) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder language(String language) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder language(Locale language) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder type(MediaType type) {
+            this.type = type;
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder type(String type) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder variant(Variant variant) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder contentLocation(URI location) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder cookie(NewCookie... cookies) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder expires(Date expires) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder lastModified(Date lastModified) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder location(URI location) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder tag(EntityTag tag) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder tag(String tag) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder variants(Variant... variants) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder variants(List<Variant> variants) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder links(Link... links) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder link(URI uri, String rel) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResponseBuilder link(String uri, String rel) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/MSSRuntimeDelegate.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/router/MSSRuntimeDelegate.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.mss.internal.router;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.Variant.VariantListBuilder;
+import javax.ws.rs.ext.RuntimeDelegate;
+
+/**
+ * <p>
+ * Implementation of the RuntimeDelegate which is
+ * required for the javax.ws.rs.core.Response
+ * <p>
+ * This class will be loaded by javax.ws.rs.ext.RuntimeDelegate
+ */
+public class MSSRuntimeDelegate extends RuntimeDelegate {
+
+
+    @Override
+    public UriBuilder createUriBuilder() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ResponseBuilder createResponseBuilder() {
+        return new MSSResponse.Builder();
+    }
+
+    @Override
+    public VariantListBuilder createVariantListBuilder() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T createEndpoint(Application application, Class<T> endpointType)
+            throws IllegalArgumentException, UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> HeaderDelegate<T> createHeaderDelegate(Class<T> type) throws IllegalArgumentException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Link.Builder createLinkBuilder() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,0 +1,1 @@
+org.wso2.carbon.mss.internal.router.MSSRuntimeDelegate

--- a/carbon-mss/components/org.wso2.carbon.mss/src/test/java/org/wso2/carbon/mss/internal/router/HttpMethodResponseHandlerTest.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/test/java/org/wso2/carbon/mss/internal/router/HttpMethodResponseHandlerTest.java
@@ -28,10 +28,10 @@ import org.junit.Test;
 import org.wso2.carbon.mss.ChunkResponder;
 import org.wso2.carbon.mss.HttpResponder;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
+import javax.annotation.Nullable;
 
 /**
  * Tests HttpMethodResponseHandlerTest class
@@ -41,7 +41,8 @@ public class HttpMethodResponseHandlerTest {
     @Test
     public void testNoStatusCodeNoEntity() {
         new HttpMethodResponseHandler()
-                .setResponder(new HttpResponderMock((HttpResponseStatus status, Object entity, Multimap<String, String> headers) -> {
+                .setResponder(new HttpResponderMock((HttpResponseStatus status,
+                                                     Object entity, Multimap<String, String> headers) -> {
                     Assert.assertTrue("Expected 204", status.code() == HttpResponseStatus.NO_CONTENT.code());
                     Assert.assertEquals(null, entity);
                 }))
@@ -51,7 +52,8 @@ public class HttpMethodResponseHandlerTest {
     @Test
     public void testNoStatusCodeWithEntity() {
         new HttpMethodResponseHandler()
-                .setResponder(new HttpResponderMock((HttpResponseStatus status, Object entity, Multimap<String, String> headers) -> {
+                .setResponder(new HttpResponderMock((HttpResponseStatus status,
+                                                     Object entity, Multimap<String, String> headers) -> {
                     Assert.assertTrue("Expected 200", status.code() == HttpResponseStatus.OK.code());
                     Assert.assertEquals("Entity", entity);
                 }))
@@ -62,7 +64,8 @@ public class HttpMethodResponseHandlerTest {
     @Test
     public void testStatusCodeOkWithNoEntity() {
         new HttpMethodResponseHandler()
-                .setResponder(new HttpResponderMock((HttpResponseStatus status, Object entity, Multimap<String, String> headers) -> {
+                .setResponder(new HttpResponderMock((HttpResponseStatus status,
+                                                     Object entity, Multimap<String, String> headers) -> {
                     Assert.assertTrue("Expected 200", status.code() == HttpResponseStatus.OK.code());
                     Assert.assertEquals(null, entity);
                 }))
@@ -73,7 +76,8 @@ public class HttpMethodResponseHandlerTest {
     @Test
     public void testStatusCodeNotFoundWithNoEntity() {
         new HttpMethodResponseHandler()
-                .setResponder(new HttpResponderMock((HttpResponseStatus status, Object entity, Multimap<String, String> headers) -> {
+                .setResponder(new HttpResponderMock((HttpResponseStatus status,
+                                                     Object entity, Multimap<String, String> headers) -> {
                     Assert.assertTrue("Expected 404", status.code() == HttpResponseStatus.NOT_FOUND.code());
                     Assert.assertEquals(null, entity);
                 }))
@@ -110,7 +114,8 @@ public class HttpMethodResponseHandlerTest {
         }
 
         @Override
-        public void sendString(HttpResponseStatus status, String data, @Nullable Multimap<String, String> headers) {
+        public void sendString(HttpResponseStatus status, String data,
+                               @Nullable Multimap<String, String> headers) {
             cb.values(status, data, headers);
         }
 
@@ -120,28 +125,33 @@ public class HttpMethodResponseHandlerTest {
         }
 
         @Override
-        public void sendStatus(HttpResponseStatus status, @Nullable Multimap<String, String> headers) {
+        public void sendStatus(HttpResponseStatus status,
+                               @Nullable Multimap<String, String> headers) {
             cb.values(status, null, headers);
         }
 
         @Override
-        public void sendByteArray(HttpResponseStatus status, byte[] bytes, @Nullable Multimap<String, String> headers) {
+        public void sendByteArray(HttpResponseStatus status, byte[] bytes,
+                                  @Nullable Multimap<String, String> headers) {
             cb.values(status, bytes, headers);
         }
 
         @Override
-        public void sendBytes(HttpResponseStatus status, ByteBuffer buffer, @Nullable Multimap<String, String> headers) {
+        public void sendBytes(HttpResponseStatus status, ByteBuffer buffer,
+                              @Nullable Multimap<String, String> headers) {
             cb.values(status, buffer, headers);
         }
 
         @Override
-        public ChunkResponder sendChunkStart(HttpResponseStatus status, @Nullable Multimap<String, String> headers) {
+        public ChunkResponder sendChunkStart(HttpResponseStatus status,
+                                             @Nullable Multimap<String, String> headers) {
             cb.values(status, null, headers);
             return null;
         }
 
         @Override
-        public void sendContent(HttpResponseStatus status, ByteBuf content, String contentType, @Nullable Multimap<String, String> headers) {
+        public void sendContent(HttpResponseStatus status, ByteBuf content, String contentType,
+                                @Nullable Multimap<String, String> headers) {
             cb.values(status, content, headers);
         }
 

--- a/carbon-mss/components/org.wso2.carbon.mss/src/test/java/org/wso2/carbon/mss/internal/router/HttpMethodResponseHandlerTest.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/test/java/org/wso2/carbon/mss/internal/router/HttpMethodResponseHandlerTest.java
@@ -1,0 +1,158 @@
+/*
+ *  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.mss.internal.router;
+
+import com.google.common.collect.Multimap;
+import com.google.gson.Gson;
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wso2.carbon.mss.ChunkResponder;
+import org.wso2.carbon.mss.HttpResponder;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
+
+/**
+ * Tests HttpMethodResponseHandlerTest class
+ */
+public class HttpMethodResponseHandlerTest {
+
+    @Test
+    public void testNoStatusCodeNoEntity() {
+        new HttpMethodResponseHandler()
+                .setResponder(new HttpResponderMock((HttpResponseStatus status, Object entity, Multimap<String, String> headers) -> {
+                    Assert.assertTrue("Expected 204", status.code() == HttpResponseStatus.NO_CONTENT.code());
+                    Assert.assertEquals(null, entity);
+                }))
+                .send();
+    }
+
+    @Test
+    public void testNoStatusCodeWithEntity() {
+        new HttpMethodResponseHandler()
+                .setResponder(new HttpResponderMock((HttpResponseStatus status, Object entity, Multimap<String, String> headers) -> {
+                    Assert.assertTrue("Expected 200", status.code() == HttpResponseStatus.OK.code());
+                    Assert.assertEquals("Entity", entity);
+                }))
+                .setEntity("Entity")
+                .send();
+    }
+
+    @Test
+    public void testStatusCodeOkWithNoEntity() {
+        new HttpMethodResponseHandler()
+                .setResponder(new HttpResponderMock((HttpResponseStatus status, Object entity, Multimap<String, String> headers) -> {
+                    Assert.assertTrue("Expected 200", status.code() == HttpResponseStatus.OK.code());
+                    Assert.assertEquals(null, entity);
+                }))
+                .setStatus(HttpResponseStatus.OK.code())
+                .send();
+    }
+
+    @Test
+    public void testStatusCodeNotFoundWithNoEntity() {
+        new HttpMethodResponseHandler()
+                .setResponder(new HttpResponderMock((HttpResponseStatus status, Object entity, Multimap<String, String> headers) -> {
+                    Assert.assertTrue("Expected 404", status.code() == HttpResponseStatus.NOT_FOUND.code());
+                    Assert.assertEquals(null, entity);
+                }))
+                .setStatus(HttpResponseStatus.NOT_FOUND.code())
+                .send();
+    }
+
+    private static class HttpResponderMock implements HttpResponder {
+
+        private final CallBack cb;
+
+        public HttpResponderMock(CallBack cb) {
+            this.cb = cb;
+        }
+
+        @Override
+        public void sendJson(HttpResponseStatus status, Object object) {
+            cb.values(status, object, null);
+        }
+
+        @Override
+        public void sendJson(HttpResponseStatus status, Object object, Type type) {
+            cb.values(status, object, null);
+        }
+
+        @Override
+        public void sendJson(HttpResponseStatus status, Object object, Type type, Gson gson) {
+            cb.values(status, object, null);
+        }
+
+        @Override
+        public void sendString(HttpResponseStatus status, String data) {
+            cb.values(status, data, null);
+        }
+
+        @Override
+        public void sendString(HttpResponseStatus status, String data, @Nullable Multimap<String, String> headers) {
+            cb.values(status, data, headers);
+        }
+
+        @Override
+        public void sendStatus(HttpResponseStatus status) {
+            cb.values(status, null, null);
+        }
+
+        @Override
+        public void sendStatus(HttpResponseStatus status, @Nullable Multimap<String, String> headers) {
+            cb.values(status, null, headers);
+        }
+
+        @Override
+        public void sendByteArray(HttpResponseStatus status, byte[] bytes, @Nullable Multimap<String, String> headers) {
+            cb.values(status, bytes, headers);
+        }
+
+        @Override
+        public void sendBytes(HttpResponseStatus status, ByteBuffer buffer, @Nullable Multimap<String, String> headers) {
+            cb.values(status, buffer, headers);
+        }
+
+        @Override
+        public ChunkResponder sendChunkStart(HttpResponseStatus status, @Nullable Multimap<String, String> headers) {
+            cb.values(status, null, headers);
+            return null;
+        }
+
+        @Override
+        public void sendContent(HttpResponseStatus status, ByteBuf content, String contentType, @Nullable Multimap<String, String> headers) {
+            cb.values(status, content, headers);
+        }
+
+        @Override
+        public void sendFile(File file, @Nullable Multimap<String, String> headers) {
+            cb.values(null, file, headers);
+        }
+    }
+
+    private static interface CallBack {
+        void values(HttpResponseStatus status, Object entity, Multimap<String, String> headers);
+    }
+
+}

--- a/carbon-mss/components/org.wso2.carbon.mss/src/test/java/org/wso2/carbon/mss/internal/router/HttpServerTest.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/test/java/org/wso2/carbon/mss/internal/router/HttpServerTest.java
@@ -439,6 +439,16 @@ public class HttpServerTest {
     }
 
     @Test
+    public void testHeaderResponse() throws IOException {
+        HttpURLConnection urlConn = request("/test/v1/headerResponse", HttpMethod.GET);
+        urlConn.addRequestProperty("name", "name1");
+
+        Assert.assertEquals(200, urlConn.getResponseCode());
+        Assert.assertEquals("name1", urlConn.getHeaderField("name"));
+        urlConn.disconnect();
+    }
+
+    @Test
     public void testDefaultQueryParam() throws IOException {
         // Submit with no parameters. Each should get the default values.
         HttpURLConnection urlConn = request("/test/v1/defaultValue", HttpMethod.GET);

--- a/carbon-mss/components/org.wso2.carbon.mss/src/test/java/org/wso2/carbon/mss/internal/router/MSSResponseTest.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/test/java/org/wso2/carbon/mss/internal/router/MSSResponseTest.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.mss.internal.router;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import javax.ws.rs.core.Response;
+
+/**
+ * Test MSSResponse and MSS ResponseBuilder
+ */
+public class MSSResponseTest {
+
+    @Test
+    public void testStatusOk() {
+        Response response = Response
+                .status(HttpResponseStatus.OK.code())
+                .build();
+        Assert.assertTrue(response.getStatus() == HttpResponseStatus.OK.code());
+    }
+
+    @Test
+    public void testStatusNotFound() {
+        Response response = Response
+                .status(HttpResponseStatus.NOT_FOUND.code())
+                .build();
+        Assert.assertTrue(response.getStatus() == HttpResponseStatus.NOT_FOUND.code());
+    }
+
+    @Test
+    public void testEntity() {
+        Response response = Response
+                .status(HttpResponseStatus.OK.code())
+                .entity("Entity")
+                .build();
+        Assert.assertTrue(response.getStatus() == HttpResponseStatus.OK.code());
+        Assert.assertEquals(response.getEntity(), "Entity");
+    }
+
+    @Test
+    public void testSingleHeaderSingleVal() {
+        Response response = Response
+                .status(HttpResponseStatus.OK.code())
+                .header("key1", "val1")
+                .build();
+        Assert.assertEquals("val1", response.getStringHeaders().getFirst("key1"));
+    }
+
+    @Test
+    public void testMultipleHeaderSingleVal() {
+        Response response = Response
+                .status(HttpResponseStatus.OK.code())
+                .header("key1", "val1")
+                .header("key2", "val2")
+                .build();
+        Assert.assertEquals("val1", response.getStringHeaders().getFirst("key1"));
+        Assert.assertEquals("val2", response.getStringHeaders().getFirst("key2"));
+    }
+
+    @Test
+    public void testSingleHeaderRepeatedSingleVal() {
+        Response response = Response
+                .status(HttpResponseStatus.OK.code())
+                .header("key1", "val1")
+                .header("key1", "val2")
+                .build();
+        Assert.assertEquals("val1", response.getStringHeaders().get("key1").get(0));
+        Assert.assertEquals("val2", response.getStringHeaders().get("key1").get(1));
+    }
+
+    @Test
+    public void testSingleHeaderListVal() {
+        Response response = Response
+                .status(HttpResponseStatus.OK.code())
+                .header("key1", Arrays.asList(new String[]{"val1", "val2"}))
+                .build();
+        Assert.assertEquals("val1", response.getStringHeaders().get("key1").get(0));
+        Assert.assertEquals("val2", response.getStringHeaders().get("key1").get(1));
+    }
+
+}

--- a/carbon-mss/components/org.wso2.carbon.mss/src/test/java/org/wso2/carbon/mss/internal/router/TestHandler.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/test/java/org/wso2/carbon/mss/internal/router/TestHandler.java
@@ -23,7 +23,6 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -52,6 +51,8 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
 
 /**
  * Test handler.
@@ -64,48 +65,48 @@ public class TestHandler implements HttpHandler {
 
     @Path("sleep/{seconds}")
     @GET
-    public void testSleep(HttpRequest request, HttpResponder responder, @PathParam("seconds") int seconds) {
+    public Response testSleep(@PathParam("seconds") int seconds) {
         try {
             TimeUnit.SECONDS.sleep(seconds);
-            responder.sendStatus(HttpResponseStatus.OK);
+            return Response.status(Response.Status.OK).entity("slept: " + seconds + "s").build();
         } catch (InterruptedException e) {
-            responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(e.getMessage()).build();
         }
     }
 
     @Path("resource")
     @GET
-    public void testGet(HttpRequest request, HttpResponder responder) {
+    public Response testGet() {
         JsonObject object = new JsonObject();
         object.addProperty("status", "Handled get in resource end-point");
-        responder.sendJson(HttpResponseStatus.OK, object);
+        return Response.status(Response.Status.OK).entity(object).build();
     }
 
     @Path("tweets/{id}")
     @GET
-    public void testGetTweet(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
+    public Response testGetTweet(@PathParam("id") String id) {
         JsonObject object = new JsonObject();
         object.addProperty("status", String.format("Handled get in tweets end-point, id: %s", id));
-        responder.sendJson(HttpResponseStatus.OK, object);
+        return Response.status(Response.Status.OK).entity(object).build();
     }
 
     @Path("tweets/{id}")
     @PUT
-    public void testPutTweet(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
+    public Response testPutTweet(@PathParam("id") String id) {
         JsonObject object = new JsonObject();
         object.addProperty("status", String.format("Handled put in tweets end-point, id: %s", id));
-        responder.sendJson(HttpResponseStatus.OK, object);
+        return Response.status(Response.Status.OK).entity(object).build();
     }
 
     @Path("facebook/{id}/message")
     @DELETE
-    public void testNoMethodRoute(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
+    public void testNoMethodRoute(@PathParam("id") String id) {
 
     }
 
     @Path("facebook/{id}/message")
     @PUT
-    public void testPutMessage(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
+    public Response testPutMessage(@PathParam("id") String id, @Context HttpRequest request) {
         String message = String.format("Handled put in tweets end-point, id: %s. ", id);
         try {
             String data = getStringContent(request);
@@ -116,12 +117,12 @@ public class TestHandler implements HttpHandler {
         }
         JsonObject object = new JsonObject();
         object.addProperty("result", message);
-        responder.sendJson(HttpResponseStatus.OK, object);
+        return Response.status(Response.Status.OK).entity(object).build();
     }
 
     @Path("facebook/{id}/message")
     @POST
-    public void testPostMessage(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
+    public Response testPostMessage(@PathParam("id") String id, @Context HttpRequest request) {
         String message = String.format("Handled post in tweets end-point, id: %s. ", id);
         try {
             String data = getStringContent(request);
@@ -132,41 +133,38 @@ public class TestHandler implements HttpHandler {
         }
         JsonObject object = new JsonObject();
         object.addProperty("result", message);
-        responder.sendJson(HttpResponseStatus.OK, object);
+        return Response.status(Response.Status.OK).entity(object).build();
     }
 
     @Path("/user/{userId}/message/{messageId}")
     @GET
-    public void testMultipleParametersInPath(HttpRequest request, HttpResponder responder,
-                                             @PathParam("userId") String userId,
-                                             @PathParam("messageId") int messageId) {
+    public Response testMultipleParametersInPath(@PathParam("userId") String userId,
+                                                 @PathParam("messageId") int messageId) {
         JsonObject object = new JsonObject();
         object.addProperty("result", String.format("Handled multiple path parameters %s %d", userId, messageId));
-        responder.sendJson(HttpResponseStatus.OK, object);
+        return Response.status(Response.Status.OK).entity(object).build();
     }
 
     @Path("/message/{messageId}/user/{userId}")
     @GET
-    public void testMultipleParametersInDifferentParameterDeclarationOrder(HttpRequest request, HttpResponder responder,
-                                                                           @PathParam("userId") String userId,
-                                                                           @PathParam("messageId") int messageId) {
+    public Response testMultipleParametersInDifferentParameterDeclarationOrder(@PathParam("userId") String userId,
+                                                                               @PathParam("messageId") int messageId) {
         JsonObject object = new JsonObject();
         object.addProperty("result", String.format("Handled multiple path parameters %s %d", userId, messageId));
-        responder.sendJson(HttpResponseStatus.OK, object);
+        return Response.status(Response.Status.OK).entity(object).build();
     }
 
     @Path("/NotRoutable/{id}")
     @GET
-    public void notRoutableParameterMismatch(HttpRequest request,
-                                             HttpResponder responder, @PathParam("userid") String userId) {
+    public Response notRoutableParameterMismatch(@PathParam("userid") String userId) {
         JsonObject object = new JsonObject();
         object.addProperty("result", String.format("Handled Not routable path %s ", userId));
-        responder.sendJson(HttpResponseStatus.OK, object);
+        return Response.status(Response.Status.OK).entity(object).build();
     }
 
     @Path("/exception")
     @GET
-    public void exception(HttpRequest request, HttpResponder responder) {
+    public void exception() {
         throw new IllegalArgumentException("Illegal argument");
     }
 
@@ -176,69 +174,67 @@ public class TestHandler implements HttpHandler {
 
     @Path("/multi-match/**")
     @GET
-    public void multiMatchAll(HttpRequest request, HttpResponder responder) {
-        responder.sendString(HttpResponseStatus.OK, "multi-match-*");
+    public String multiMatchAll() {
+        return "multi-match-*";
     }
 
     @Path("/multi-match/{param}")
     @GET
-    public void multiMatchParam(HttpRequest request, HttpResponder responder, @PathParam("param") String param) {
-        responder.sendString(HttpResponseStatus.OK, "multi-match-param-" + param);
+    public String multiMatchParam(@PathParam("param") String param) {
+        return "multi-match-param-" + param;
     }
 
     @Path("/multi-match/foo")
     @GET
-    public void multiMatchFoo(HttpRequest request, HttpResponder responder) {
-        responder.sendString(HttpResponseStatus.OK, "multi-match-get-actual-foo");
+    public String multiMatchFoo() {
+        return "multi-match-get-actual-foo";
     }
 
     @Path("/multi-match/foo")
     @PUT
-    public void multiMatchParamPut(HttpRequest request, HttpResponder responder) {
-        responder.sendString(HttpResponseStatus.OK, "multi-match-put-actual-foo");
+    public String multiMatchParamPut() {
+        return "multi-match-put-actual-foo";
     }
 
     @Path("/multi-match/{param}/bar")
     @GET
-    public void multiMatchParamBar(HttpRequest request, HttpResponder responder, @PathParam("param") String param) {
-        responder.sendString(HttpResponseStatus.OK, "multi-match-param-bar-" + param);
+    public String multiMatchParamBar(@PathParam("param") String param) {
+        return "multi-match-param-bar-" + param;
     }
 
     @Path("/multi-match/foo/{param}")
     @GET
-    public void multiMatchFooParam(HttpRequest request, HttpResponder responder, @PathParam("param") String param) {
-        responder.sendString(HttpResponseStatus.OK, "multi-match-get-foo-param-" + param);
+    public String multiMatchFooParam(@PathParam("param") String param) {
+        return "multi-match-get-foo-param-" + param;
     }
 
     @Path("/multi-match/foo/{param}/bar")
     @GET
-    public void multiMatchFooParamBar(HttpRequest request, HttpResponder responder, @PathParam("param") String param) {
-        responder.sendString(HttpResponseStatus.OK, "multi-match-foo-param-bar-" + param);
+    public String multiMatchFooParamBar(@PathParam("param") String param) {
+        return "multi-match-foo-param-bar-" + param;
     }
 
     @Path("/multi-match/foo/bar/{param}")
     @GET
-    public void multiMatchFooBarParam(HttpRequest request, HttpResponder responder, @PathParam("param") String param) {
-        responder.sendString(HttpResponseStatus.OK, "multi-match-foo-bar-param-" + param);
+    public String multiMatchFooBarParam(@PathParam("param") String param) {
+        return "multi-match-foo-bar-param-" + param;
     }
 
     @Path("/multi-match/foo/{param}/bar/baz")
     @GET
-    public void multiMatchFooParamBarBaz(HttpRequest request, HttpResponder responder,
-                                         @PathParam("param") String param) {
-        responder.sendString(HttpResponseStatus.OK, "multi-match-foo-param-bar-baz-" + param);
+    public String multiMatchFooParamBarBaz(@PathParam("param") String param) {
+        return "multi-match-foo-param-bar-baz-" + param;
     }
 
     @Path("/multi-match/foo/bar/{param}/{id}")
     @GET
-    public void multiMatchFooBarParamId(HttpRequest request, HttpResponder responder,
-                                        @PathParam("param") String param, @PathParam("id") String id) {
-        responder.sendString(HttpResponseStatus.OK, "multi-match-foo-bar-param-" + param + "-id-" + id);
+    public String multiMatchFooBarParamId(@PathParam("param") String param, @PathParam("id") String id) {
+        return "multi-match-foo-bar-param-" + param + "-id-" + id;
     }
 
     @Path("/stream/upload")
     @PUT
-    public BodyConsumer streamUpload(HttpRequest request, HttpResponder responder) {
+    public BodyConsumer streamUpload() {
         final int fileSize = 30 * 1024 * 1024;
         return new BodyConsumer() {
             ByteBuf offHeapBuffer = Unpooled.buffer(fileSize);
@@ -266,7 +262,7 @@ public class TestHandler implements HttpHandler {
 
     @Path("/stream/upload/fail")
     @PUT
-    public BodyConsumer streamUploadFailure(HttpRequest request, HttpResponder responder) {
+    public BodyConsumer streamUploadFailure() {
         final int fileSize = 30 * 1024 * 1024;
 
         return new BodyConsumer() {
@@ -294,10 +290,10 @@ public class TestHandler implements HttpHandler {
 
     @Path("/aggregate/upload")
     @PUT
-    public void aggregatedUpload(HttpRequest request, HttpResponder response) {
+    public String aggregatedUpload(@Context HttpRequest request) {
         ByteBuf content = ((FullHttpRequest) request).content();
         int bytesUploaded = content.readableBytes();
-        response.sendString(HttpResponseStatus.OK, "Uploaded:" + bytesUploaded);
+        return "Uploaded:" + bytesUploaded;
     }
 
     @Path("/chunk")
@@ -314,73 +310,68 @@ public class TestHandler implements HttpHandler {
 
     @Path("/uexception")
     @GET
-    public void testException(HttpRequest request, HttpResponder responder) {
+    public void testException() {
         throw Throwables.propagate(new RuntimeException("User Exception"));
     }
 
     @Path("/noresponse")
     @GET
-    public void testNoResponse(HttpRequest request, HttpResponder responder) {
+    public void testNoResponse() {
     }
 
     @Path("/stringQueryParam/{path}")
     @GET
-    public void testStringQueryParam(HttpRequest request, HttpResponder responder,
-                                     @PathParam("path") String path, @QueryParam("name") String name) {
-        responder.sendString(HttpResponseStatus.OK, path + ":" + name);
+    public String testStringQueryParam(@PathParam("path") String path, @QueryParam("name") String name) {
+        return path + ":" + name;
     }
 
     @Path("/primitiveQueryParam")
     @GET
-    public void testPrimitiveQueryParam(HttpRequest request, HttpResponder responder, @QueryParam("age") int age) {
-        responder.sendString(HttpResponseStatus.OK, Integer.toString(age));
+    public String testPrimitiveQueryParam(@QueryParam("age") int age) {
+        return Integer.toString(age);
     }
 
     @Path("/sortedSetQueryParam")
     @GET
-    public void testSortedSetQueryParam(HttpRequest request, HttpResponder responder,
-                                        @QueryParam("id") SortedSet<Integer> ids) {
-        responder.sendString(HttpResponseStatus.OK, Joiner.on(',').join(ids));
+    public String testSortedSetQueryParam(@QueryParam("id") SortedSet<Integer> ids) {
+        return Joiner.on(',').join(ids);
     }
 
     @Path("/listHeaderParam")
     @GET
-    public void testListHeaderParam(HttpRequest request, HttpResponder responder,
-                                    @HeaderParam("name") List<String> names) {
-        responder.sendString(HttpResponseStatus.OK, Joiner.on(',').join(names));
+    public String testListHeaderParam(@HeaderParam("name") List<String> names) {
+        return Joiner.on(',').join(names);
     }
 
     @Path("/defaultValue")
     @GET
-    public void testDefaultValue(HttpRequest request, HttpResponder responder,
-                                 @DefaultValue("30") @QueryParam("age") Integer age,
-                                 @DefaultValue("hello") @QueryParam("name") String name,
-                                 @DefaultValue("casking") @HeaderParam("hobby") List<String> hobbies) {
+    public Object testDefaultValue(@DefaultValue("30") @QueryParam("age") Integer age,
+                                   @DefaultValue("hello") @QueryParam("name") String name,
+                                   @DefaultValue("casking") @HeaderParam("hobby") List<String> hobbies) {
         JsonObject response = new JsonObject();
         response.addProperty("age", age);
         response.addProperty("name", name);
         response.add("hobby", GSON.toJsonTree(hobbies, new TypeToken<List<String>>() {
         }.getType()));
 
-        responder.sendJson(HttpResponseStatus.OK, response);
+        return response;
     }
 
     @Path("/connectionClose")
     @GET
-    public void testConnectionClose(HttpRequest request, HttpResponder responder) {
-        responder.sendString(HttpResponseStatus.OK, "Close connection", ImmutableMultimap.of("Connection", "close"));
+    public Response testConnectionClose() {
+        return Response.status(Response.Status.OK).entity("Close connection").header("Connection", "close").build();
     }
 
     @Path("/uploadReject")
     @POST
-    public BodyConsumer testUploadReject(HttpRequest request, HttpResponder responder) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Rejected", ImmutableMultimap.of("Connection", "close"));
-        return null;
+    public Response testUploadReject() {
+        return Response.status(Response.Status.BAD_REQUEST).entity("Rejected").header("Connection", "close").build();
     }
 
     @Path("/customException")
     @POST
-    public void testCustomException(HttpRequest request, HttpResponder responder) throws CustomException {
+    public void testCustomException() throws CustomException {
         throw new CustomException();
     }
 

--- a/carbon-mss/components/org.wso2.carbon.mss/src/test/java/org/wso2/carbon/mss/internal/router/TestHandler.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/test/java/org/wso2/carbon/mss/internal/router/TestHandler.java
@@ -343,6 +343,12 @@ public class TestHandler implements HttpHandler {
         return Joiner.on(',').join(names);
     }
 
+    @Path("/headerResponse")
+    @GET
+    public Response testHeaderResponse(@HeaderParam("name") String name) {
+        return Response.status(HttpResponseStatus.OK.code()).entity("Entity").header("name", name).build();
+    }
+
     @Path("/defaultValue")
     @GET
     public Object testDefaultValue(@DefaultValue("30") @QueryParam("age") Integer age,


### PR DESCRIPTION
-Removed io.netty.handler.codec.http.HttpRequest and org.wso2.carbon.mss.HttpResponder coupling from resource methods.
-Support for sending HTTP responses through the return.
-Support for @Context for parameter injection.
-Support returning javax.ws.rs.core.Response.
-Removing jersey dependency to javax.ws.rs.core.Response implementation by implementing own javax.ws.rs.core.Response.
-Changing all tests to support new decoupled resource methods.
-Tests for javax.ws.rs.core.Response implementation.