### PR TITLE
Set project build source encoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,7 @@
     </build>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Maven plugins -->
         <maven.checkstyleplugin.version>2.16</maven.checkstyleplugin.version>
         <maven.findbugsplugin.version>3.0.2</maven.findbugsplugin.version>


### PR DESCRIPTION
This should fix following warning:
[WARNING] Source files encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
